### PR TITLE
Bump check version and ignore default limits.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-awslimitchecker==0.7.0
+awslimitchecker==0.8.0
 marshmallow==2.11.1
 requests==2.12.5
 webargs==1.5.2


### PR DESCRIPTION
Now that awslimitchecker 0.8 is out, we can monitor ec2 on govcloud. Unfortunately, that means we get a bunch of spurious warnings about per-instance-type limits that aren't exposed via API, so this patch ignores them all.