### PR TITLE
Update dependencies to latest.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,0 @@
-applications:
-- name: cf-limit-check
-  buildpack: python_buildpack
-  command: ./check.py
-  health-check-type: none
-  no-route: true
-  memory: 256M

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-awslimitchecker==0.10.0
-marshmallow==2.11.1
-requests==2.12.5
-webargs==1.5.2
+awslimitchecker==2.0.0
+marshmallow==2.14.0
+requests==2.18.4
+webargs==1.8.1


### PR DESCRIPTION
The upstream limit checker shipped a few major releases. Bumping other dependencies while we're at it.